### PR TITLE
Fix broken razor dependencies

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="SolutionArtifacts" value="./artifacts" />
+    <add key="SolutionArtifacts" value="artifacts" />
     <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json" />
     <add key="AspNetCoreTools" value="https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />

--- a/build-packages.cmd
+++ b/build-packages.cmd
@@ -2,7 +2,7 @@
 
 @rem -- Building corlib using .NETFramework/mono tools (not .NET Core) because it needs to use NoStdLib option, and
 @rem -- I haven't figured out how to configure the equivalent to that with .NET Core build tools.
-SET msbuildExePath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBuild.exe"
+SET msbuildExePath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"
 %msbuildExePath% src\DNA\corlib\corlib.csproj
 
 @rem -- Other projects have to be built in a specific order, because they mostly consume each other via package

--- a/build-vsextension.cmd
+++ b/build-vsextension.cmd
@@ -11,7 +11,7 @@ rem Note that file whose name starts "sw-" are automatically omitted from the pr
 copy /y .\template\MyApplication\Properties\sw-launchSettings.json .\template\MyApplication\Properties\launchSettings.json
 
 rem Actually build the VSIX
-SET msbuildExePath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBuild.exe"
+SET msbuildExePath="C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"
 %msbuildExePath% src\Blazor.VSExtension\Blazor.VSExtension.csproj
 
 rem Move launchSettings.json back to clean state

--- a/src/Blazor.Compiler/Blazor.Compiler.csproj
+++ b/src/Blazor.Compiler/Blazor.Compiler.csproj
@@ -11,11 +11,11 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Razor" Version="2.0.0-preview2-24923" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="2.0.0-preview2-24923" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="2.0.0-preview1-final" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.1.0" />
-    <PackageReference Include="Blazor.Runtime" Version="0.1.0-*" />
-    <PackageReference Include="Blazor.AngleSharp" Version="0.1.0-*" />
+    <PackageReference Include="Blazor.Runtime" Version="0.2.0-*" />
+    <PackageReference Include="Blazor.AngleSharp" Version="0.2.0-*" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Blazor.Host/Blazor.Host.csproj
+++ b/src/Blazor.Host/Blazor.Host.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.ResponseCompression" Version="1.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.1" />
-    <PackageReference Include="Blazor.Compiler" Version="0.1.0-*" />
+    <PackageReference Include="Blazor.Compiler" Version="0.2.0-*" />
     <PackageReference Include="System.IO.FileSystem.Watcher" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/template/MyApplication/MyApplication.csproj
+++ b/template/MyApplication/MyApplication.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Blazor.Compiler" Version="0.1.0-*" />
-    <PackageReference Include="Blazor.Runtime" Version="0.1.0-*" />
-    <DotNetCliToolReference Include="Blazor.Host" Version="0.1.0-*" />
+    <PackageReference Include="Blazor.Compiler" Version="0.2.0-*" />
+    <PackageReference Include="Blazor.Runtime" Version="0.2.0-*" />
+    <DotNetCliToolReference Include="Blazor.Host" Version="0.2.0-*" />
   </ItemGroup>
 </Project>

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <VersionSuffix>build$([System.DateTime]::Now.ToString('yyyyMMdd-HHmmss'))</VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The preview2 razor dependencies no longer exist on the aspnetcore dev feeds, and the latest builds of the razor packages contain a breaking api change. This change moves the razor dependencies back to preview1 until preview2 has officially shipped.