### PR TITLE
Fix Delegate Equals() method

### DIFF
--- a/src/DNA/corlib/System/Delegate.cs
+++ b/src/DNA/corlib/System/Delegate.cs
@@ -14,7 +14,8 @@ namespace System {
 			if (d == null) {
 				return false;
 			}
-			return d.targetObj == this.targetObj && d.targetMethod.Equals(this.targetMethod);
+			// DNA currently can't handle boxing an IntPtr, so use the '==' overload instead (which doesn't have boxing)
+			return d.targetObj == this.targetObj && d.targetMethod == this.targetMethod;
 		}
 
 		public override int GetHashCode() {


### PR DESCRIPTION
Simple fix for the underlying issue of the bug described [here](https://github.com/SteveSanderson/Blazor/blob/master/src/Blazor.Runtime/Interop/ManagedGCHandle.cs#L12-L13):

> // because the DotNetAnywhere runtime crashes if you try to put a *delegate* instance
> // as a key into a Dictionary and then check whether dict.ContainsKey(thatDelegate).

Tested with code like this:

``` csharp
Action actionA = new Action(TestMethod);
Action actionB = new Action(SomeOtherMethod);
Action actionC = new Action(TestMethod); // same Target as actionA

// Before the fix calling 'Equals() give the error "Opcode not available: 0x0000006c"
Console.WriteLine("actionA.Equals(actionB) = {0}", actionA.Equals(actionB)); // False
Console.WriteLine("actionA.Equals(actionC) = {0}", actionA.Equals(actionC)); // True
```

To properly allow DNA to handle boxing/unboxing of `IntPtr`, support would have to be added for:

- `JIT_BOX_PTR` (*probably* [here](https://github.com/SteveSanderson/Blazor/blob/master/src/DNA/native/src/JIT_Execute.c#L2965-L2981)) 
- `UNBOX` CIL op-code (`CIL_UNBOX_ANY` is already supported)