### PR TITLE
P/Invoke fixes

### DIFF
--- a/src/DNA/native/src/JIT.h
+++ b/src/DNA/native/src/JIT.h
@@ -24,17 +24,19 @@
 typedef struct tJITted_ tJITted;
 typedef struct tExceptionHeader_ tExceptionHeader;
 
-// [Steve] This overly-specific-looking int-returning 3-STRING-arg signature is because it's difficult
-// to support arbitrary signatures given Emscripten's limitations around needing to know the original
-// type of a function pointer when invoking it: https://kripken.github.io/emscripten-site/docs/porting/guidelines/function_pointer_issues.html
-// My workaround is just to hard-code this as the only possible PInvoke method signature and then skip
-// the code in PInvoke.c that tries to dynamically select a function pointer type.
-//
-// With more work I'm sure it would be possible to figure out a mechanism for getting the original
-// Pinvoke.c logic to work. It might even just be as simple as changing the return type of fnPInvoke from int
-// to U64, since it looks like that's hardcoded as the return type in Pinvoke.c. But I don't need to deal
-// with that now.
-typedef int(*fnPInvoke)(STRING libName, STRING funcName, STRING arg0);
+// ** memsom => the problem with doing this is that we can't ever work around it.
+// ** hardcoding like this means that the P/Invoke interface is fixed.
+//// [Steve] This overly-specific-looking int-returning 3-STRING-arg signature is because it's difficult
+//// to support arbitrary signatures given Emscripten's limitations around needing to know the original
+//// type of a function pointer when invoking it: https://kripken.github.io/emscripten-site/docs/porting/guidelines/function_pointer_issues.html
+//// My workaround is just to hard-code this as the only possible PInvoke method signature and then skip
+//// the code in PInvoke.c that tries to dynamically select a function pointer type.
+////
+//// With more work I'm sure it would be possible to figure out a mechanism for getting the original
+//// Pinvoke.c logic to work. It might even just be as simple as changing the return type of fnPInvoke from int
+//// to U64, since it looks like that's hardcoded as the return type in Pinvoke.c. But I don't need to deal
+//// with that now.
+//typedef int(*fnPInvoke)(STRING libName, STRING funcName, STRING arg0);
 
 #include "Types.h"
 
@@ -107,7 +109,7 @@ typedef struct tJITCallPInvoke_ tJITCallPInvoke;
 struct tJITCallPInvoke_ {
 	U32 opCode;
 	// The native function to call
-	fnPInvoke fn;
+	void* fn; //fnPInvoke fn; // <== this can't be declared like this anymore
 	// The method that is being called
 	tMD_MethodDef *pMethod;
 	// The ImplMap of the function that's being called

--- a/src/DNA/native/src/PInvoke.h
+++ b/src/DNA/native/src/PInvoke.h
@@ -26,6 +26,8 @@
 #include "String.h"
 
 extern char* invokeJsFunc(STRING libName, STRING funcName, STRING arg0);
+typedef void* fnPInvoke;
+ 
 fnPInvoke PInvoke_GetFunction(tMetaData *pMetaData, tMD_ImplMap *pImplMap);
 U32 PInvoke_Call(tJITCallPInvoke *pCall, PTR pParams, PTR pReturnValue, tThread *pCallingThread);
 


### PR DESCRIPTION
This makes the P/Invoke interface work again.

No idea is this will be useful, but it really does put things back to working in a pure DNA built on to run on the command line.

I think that adding in the extra params was the main mistake. This makes the P/Invoke fall in to a little heap on the floor. I think making an extra attribute or calling convention for the C# side would be a better method for getting this working. More metadata would allow you to automagically add the extra params when they are required.